### PR TITLE
Issue #3028334 by babusaheb.vikas, balazswmann: swagger-ui libraries is not working from profile distribution

### DIFF
--- a/swagger_ui_formatter.install
+++ b/swagger_ui_formatter.install
@@ -39,6 +39,13 @@ function swagger_ui_formatter_requirements($phase) {
 }
 
 /**
+ * Implements hook_uninstall().
+ */
+function swagger_ui_formatter_uninstall() {
+  \Drupal::cache()->invalidate('swagger_ui_formatter:library_path');
+}
+
+/**
  * Clear cache due to updated library definitions.
  */
 function swagger_ui_formatter_update_8001() {

--- a/swagger_ui_formatter.module
+++ b/swagger_ui_formatter.module
@@ -7,6 +7,7 @@
 
 use Drupal\Component\Serialization\Json;
 use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\DrupalKernel;
 
 /**
  * Implements hook_theme().
@@ -69,15 +70,31 @@ function _swagger_ui_formatter_get_library_path() {
   if ($cache = \Drupal::cache()->get($cid)) {
     return $cache->data;
   }
-  else {
-    foreach (['/libraries/swagger-ui', '/libraries/swagger_ui'] as $library_dir) {
-      if (_swagger_ui_formatter_is_library_directory($library_dir)) {
-        \Drupal::cache()->set($cid, $library_dir);
-        return $library_dir;
+
+  $directories = [];
+  // Search inside the install profile.
+  if ($profile = \Drupal::installProfile()) {
+    $profile_path = drupal_get_path('profile', $profile);
+    $directories[] = "/$profile_path/libraries";
+  }
+  // Search inside sites/all/libraries for backwards-compatibility.
+  $directories[] = '/sites/all/libraries';
+  // Search inside the root libraries directory.
+  $directories[] = '/libraries';
+  // Finally search inside sites/<domain>/libraries.
+  $site_path = DrupalKernel::findSitePath(\Drupal::request());
+  $directories[] = "/$site_path/libraries";
+
+  foreach ($directories as $directory) {
+    foreach (['swagger-ui', 'swagger_ui'] as $library) {
+      $library_path = $directory . '/' . $library;
+      if (_swagger_ui_formatter_is_library_directory($library_path)) {
+        \Drupal::cache()->set($cid, $library_path);
+        return $library_path;
       }
     }
-    return FALSE;
   }
+  return FALSE;
 }
 
 /**


### PR DESCRIPTION
[Issue #3028334](https://www.drupal.org/project/swagger_ui_formatter/issues/3028334)

The [Libraries](https://www.drupal.org/project/libraries) module can handle this with its `libraries_get_path()` function but the module is still in alpha state and looks like the development is not active. That's the reason why we have an own function to determine the library path, so we don't have to depend on Libraries.