### PR TITLE
Issue #3044973 by balazswmann, mxr576: Do not add SVG definitions to the DOM in case of Swagger UI v3.13.4 or newer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,5 +11,8 @@
       "homepage": "https://www.drupal.org/u/balazswmann",
       "role": "Maintainer"
     }
-  ]
+  ],
+  "require": {
+    "symfony/dom-crawler": "~3.4|~4.0"
+  }
 }

--- a/js/swagger-ui-formatter.js
+++ b/js/swagger-ui-formatter.js
@@ -7,10 +7,6 @@
 
   Drupal.behaviors.swaggerUIFormatter = {
     attach: function(context) {
-      // Add SVG definitions to the DOM (no longer needed since v3.13.4).
-      // @see https://github.com/swagger-api/swagger-ui/releases/tag/v3.13.4
-      $('body', context).once('swagger-ui-svg-definitions').prepend(swaggerUISVGDefinitions());
-
       // Iterate over fields and render each field item with Swagger UI.
       for (var fieldName in drupalSettings.swaggerUIFormatter) {
         if (drupalSettings.swaggerUIFormatter.hasOwnProperty(fieldName)) {
@@ -20,6 +16,11 @@
             // before (avoid re-rendering on AJAX requests for example).
             if ('swagger_ui_' + fieldName + '_' + fieldDelta in window) {
               continue;
+            }
+
+            // Add SVG definition to the DOM (old Swagger UI requirement).
+            if (field.svgDefinition) {
+              $('body', context).once('swagger-ui-svg-definition').prepend(field.svgDefinition);
             }
 
             var validatorUrl = undefined;
@@ -62,43 +63,5 @@
       }
     }
   };
-
-  /**
-   * Gets the SVG definitions required for Swagger UI.
-   *
-   * No longer needed since Swagger UI v3.13.4.
-   *
-   * @see https://github.com/swagger-api/swagger-ui/releases/tag/v3.13.4
-   * @see assets/vendor/swagger-ui/index.html
-   *
-   * @returns {string}
-   */
-  function swaggerUISVGDefinitions() {
-      return '<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="position:absolute;width:0;height:0">\
-        <defs>\
-          <symbol viewBox="0 0 20 20" id="unlocked">\
-            <path d="M15.8 8H14V5.6C14 2.703 12.665 1 10 1 7.334 1 6 2.703 6 5.6V6h2v-.801C8 3.754 8.797 3 10 3c1.203 0 2 .754 2 2.199V8H4c-.553 0-1 .646-1 1.199V17c0 .549.428 1.139.951 1.307l1.197.387C5.672 18.861 6.55 19 7.1 19h5.8c.549 0 1.428-.139 1.951-.307l1.196-.387c.524-.167.953-.757.953-1.306V9.199C17 8.646 16.352 8 15.8 8z"></path>\
-          </symbol>\
-          <symbol viewBox="0 0 20 20" id="locked">\
-            <path d="M15.8 8H14V5.6C14 2.703 12.665 1 10 1 7.334 1 6 2.703 6 5.6V8H4c-.553 0-1 .646-1 1.199V17c0 .549.428 1.139.951 1.307l1.197.387C5.672 18.861 6.55 19 7.1 19h5.8c.549 0 1.428-.139 1.951-.307l1.196-.387c.524-.167.953-.757.953-1.306V9.199C17 8.646 16.352 8 15.8 8zM12 8H8V5.199C8 3.754 8.797 3 10 3c1.203 0 2 .754 2 2.199V8z"/>\
-          </symbol>\
-          <symbol viewBox="0 0 20 20" id="close">\
-            <path d="M14.348 14.849c-.469.469-1.229.469-1.697 0L10 11.819l-2.651 3.029c-.469.469-1.229.469-1.697 0-.469-.469-.469-1.229 0-1.697l2.758-3.15-2.759-3.152c-.469-.469-.469-1.228 0-1.697.469-.469 1.228-.469 1.697 0L10 8.183l2.651-3.031c.469-.469 1.228-.469 1.697 0 .469.469.469 1.229 0 1.697l-2.758 3.152 2.758 3.15c.469.469.469 1.229 0 1.698z"/>\
-          </symbol>\
-          <symbol viewBox="0 0 20 20" id="large-arrow">\
-            <path d="M13.25 10L6.109 2.58c-.268-.27-.268-.707 0-.979.268-.27.701-.27.969 0l7.83 7.908c.268.271.268.709 0 .979l-7.83 7.908c-.268.271-.701.27-.969 0-.268-.269-.268-.707 0-.979L13.25 10z"/>\
-          </symbol>\
-          <symbol viewBox="0 0 20 20" id="large-arrow-down">\
-            <path d="M17.418 6.109c.272-.268.709-.268.979 0s.271.701 0 .969l-7.908 7.83c-.27.268-.707.268-.979 0l-7.908-7.83c-.27-.268-.27-.701 0-.969.271-.268.709-.268.979 0L10 13.25l7.418-7.141z"/>\
-          </symbol>\
-          <symbol viewBox="0 0 24 24" id="jump-to">\
-            <path d="M19 7v4H5.83l3.58-3.59L8 6l-6 6 6 6 1.41-1.41L5.83 13H21V7z"/>\
-          </symbol>\
-          <symbol viewBox="0 0 24 24" id="expand">\
-            <path d="M10 18h4v-2h-4v2zM3 6v2h18V6H3zm3 7h12v-2H6v2z"/>\
-          </symbol>\
-        </defs>\
-      </svg>';
-  }
 
 }(jQuery, window, Drupal, drupalSettings));

--- a/src/Plugin/Field/FieldFormatter/SwaggerUIFormatterTrait.php
+++ b/src/Plugin/Field/FieldFormatter/SwaggerUIFormatterTrait.php
@@ -128,7 +128,7 @@ trait SwaggerUIFormatterTrait {
    * @return array
    *   A renderable array of the field element with attached libraries.
    */
-  public function attachLibraries(array $element, array $swagger_files) {
+  protected function attachLibraries(array $element, array $swagger_files) {
     if (!empty($swagger_files) && _swagger_ui_formatter_get_library_path()) {
       $element['#attached'] = [
         'library' => [
@@ -138,6 +138,7 @@ trait SwaggerUIFormatterTrait {
         'drupalSettings' => [
           'swaggerUIFormatter' => [
             $this->fieldDefinition->getName() => [
+              'svgDefinition' => _swagger_ui_formatter_get_svg_definition(),
               'swaggerFiles' => $swagger_files,
               'validator' => $this->getSetting('validator'),
               'validatorUrl' => $this->getSetting('validator_url'),

--- a/swagger_ui_formatter.module
+++ b/swagger_ui_formatter.module
@@ -7,6 +7,17 @@
 
 use Drupal\Component\Serialization\Json;
 use Drupal\Core\Routing\RouteMatchInterface;
+use Symfony\Component\DomCrawler\Crawler;
+
+/**
+ * Swagger UI library path related cache ID.
+ */
+const SWAGGER_UI_FORMATTER_LIBRARY_PATH_CID = 'swagger_ui_formatter:library_path';
+
+/**
+ * Swagger UI SVG definition related cache ID.
+ */
+const SWAGGER_UI_FORMATTER_SVG_DEFINITION_CID = 'swagger_ui_formatter:svg_definition';
 
 /**
  * Implements hook_theme().
@@ -65,14 +76,13 @@ function swagger_ui_formatter_library_info_build() {
  *   Returns the library path or FALSE if the library is not found.
  */
 function _swagger_ui_formatter_get_library_path() {
-  $cid = 'swagger_ui_formatter:library_path';
-  if ($cache = \Drupal::cache()->get($cid)) {
+  if ($cache = \Drupal::cache()->get(SWAGGER_UI_FORMATTER_LIBRARY_PATH_CID)) {
     return $cache->data;
   }
   else {
     foreach (['/libraries/swagger-ui', '/libraries/swagger_ui'] as $library_dir) {
       if (_swagger_ui_formatter_is_library_directory($library_dir)) {
-        \Drupal::cache()->set($cid, $library_dir);
+        \Drupal::cache()->set(SWAGGER_UI_FORMATTER_LIBRARY_PATH_CID, $library_dir);
         return $library_dir;
       }
     }
@@ -117,19 +127,43 @@ function _swagger_ui_formatter_get_library_version() {
     if (!file_exists($file)) {
       return '';
     }
-
     $content = file_get_contents($file);
     if (!$content) {
       return '';
     }
-
     $data = Json::decode($content);
     if (isset($data['version'])) {
       return $data['version'];
     }
   }
-
   return '';
+}
+
+/**
+ * Gets Swagger UI related SVG definition.
+ *
+ * Since Swagger UI v3.13.4 there is no need to include the <svg> tag in HTML.
+ *
+ * @see https://github.com/swagger-api/swagger-ui/releases/tag/v3.13.4
+ *
+ * @return string|NULL
+ *   The required <svg> tag as a HTML string or NULL if it doesn't exist.
+ */
+function _swagger_ui_formatter_get_svg_definition() {
+  if ($cache = \Drupal::cache()->get(SWAGGER_UI_FORMATTER_SVG_DEFINITION_CID)) {
+    return $cache->data;
+  }
+  $library_path = _swagger_ui_formatter_get_library_path();
+  if ($library_path && file_exists(DRUPAL_ROOT . $library_path . '/dist/index.html')) {
+    $dom_crawler = new Crawler(file_get_contents(DRUPAL_ROOT . $library_path . '/dist/index.html'));
+    $dom_crawler = $dom_crawler->filterXPath('descendant-or-self::body/svg');
+    if ($domElement = $dom_crawler->getNode(0)) {
+      $svg = $domElement->ownerDocument->saveHTML($domElement);
+      \Drupal::cache()->set(SWAGGER_UI_FORMATTER_SVG_DEFINITION_CID, $svg);
+      return $svg;
+    }
+  }
+  return NULL;
 }
 
 /**
@@ -161,4 +195,12 @@ function swagger_ui_formatter_help($route_name, RouteMatchInterface $route_match
 
       return $output;
   }
+}
+
+/**
+ * Implements hook_cache_flush().
+ */
+function swagger_ui_formatter_cache_flush() {
+  \Drupal::cache()->invalidate(SWAGGER_UI_FORMATTER_LIBRARY_PATH_CID);
+  \Drupal::cache()->invalidate(SWAGGER_UI_FORMATTER_SVG_DEFINITION_CID);
 }


### PR DESCRIPTION
Issue [#3044973](https://www.drupal.org/project/swagger_ui_formatter/issues/3044973)

Unfortunately there is no way to collect SVG definition from a simpler and cleaner way as I saw, only the `/dist/index.html` contains it. That's the reason of the DOM Crawler.