### PR TITLE
Issue #3051703 by balazswmann: Add missing core/jquery.once dependency to swagger_ui_integration library definition

### DIFF
--- a/swagger_ui_formatter.install
+++ b/swagger_ui_formatter.install
@@ -10,7 +10,6 @@
  */
 function swagger_ui_formatter_requirements($phase) {
   $requirements = [];
-
   if ($phase == 'runtime') {
     if ($library_path = _swagger_ui_formatter_get_library_path()) {
       $requirements['swagger_ui_library'] = [
@@ -34,7 +33,6 @@ function swagger_ui_formatter_requirements($phase) {
       ];
     }
   }
-
   return $requirements;
 }
 

--- a/swagger_ui_formatter.module
+++ b/swagger_ui_formatter.module
@@ -59,13 +59,13 @@ function swagger_ui_formatter_library_info_build() {
         'js/swagger-ui-formatter.js' => [],
       ],
       'dependencies' => [
-        'core/jquery',
         'core/drupal',
+        'core/jquery',
+        'core/jquery.once',
         'core/drupalSettings',
       ],
     ];
   }
-
   return $libraries;
 }
 

--- a/swagger_ui_formatter.post_update.php
+++ b/swagger_ui_formatter.post_update.php
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * @file
+ * Post update functions for Swagger UI Field Formatter.
+ */
+
+/**
+ * Clear cache due to updated library definitions.
+ */
+function swagger_ui_formatter_post_update_1() {
+  // Empty post-update hook.
+}


### PR DESCRIPTION
Issue [#3051703](https://www.drupal.org/project/swagger_ui_formatter/issues/3051703)