### PR TITLE
Issue #3058177 by tamasd: Fix config schema

### DIFF
--- a/config/schema/swagger_ui_formatter.schema.yml
+++ b/config/schema/swagger_ui_formatter.schema.yml
@@ -1,6 +1,5 @@
-field.formatter.settings.swagger_ui:
+field_formatter_settings_swagger_ui_base:
   type: mapping
-  label: 'Swagger UI field formatter settings'
   mapping:
     validator:
       type: string
@@ -22,3 +21,11 @@ field.formatter.settings.swagger_ui:
       sequence:
         type: string
       label: 'Try it out support for HTTP Methods'
+
+field.formatter.settings.swagger_ui_file:
+  type: field_formatter_settings_swagger_ui_base
+  label: 'Swagger UI file field formatter settings'
+
+field.formatter.settings.swagger_ui_link:
+  type: field_formatter_settings_swagger_ui_base
+  label: 'Swagger UI link field formatter settings'


### PR DESCRIPTION
[Issue #3058177](https://www.drupal.org/project/swagger_ui_formatter/issues/3058177)

The machine name of the field was changed recently to swagger_ui_file,
but this change was not reflected in the config schema file.

Because of this, the module cannot be enabled in tests.