### PR TITLE
Issue #3059081 by Boobaa: Fix instructions for pulling in Swagger UI JS lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ It's also needed to extend the 'installer-path' section:
         "type:bower-asset",
         "type:npm-asset"
     ],
+    "web/libraries/swagger_ui": ["bower-asset/swagger-ui"],
 ```
 And add a new 'installer-types' section next to the 'installer-path' in the 'extra' section:
 
@@ -81,7 +82,7 @@ And add a new 'installer-types' section next to the 'installer-path' in the 'ext
 After this you can install the library with:
 
 ```shell
-composer require oomphinc/composer-installers-extender npm-asset/swagger-ui
+composer require oomphinc/composer-installers-extender bower-asset/swagger-ui
 ```
 The library will be downloaded into the libraries folder.
 


### PR DESCRIPTION
As `npm-asset/swagger-ui` cannot be installed because of dependency problems, we must switch to `bower-asset/swagger-ui` which _can_ be installed, tho its path also needs to be defined explicitly.