### PR TITLE
Temporary workaround for a Drupal packaging issue

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "license": "GPL-2.0-or-later",
     "require": {
         "php": "^7.2",
-        "drupal/core-recommended": "~8.9.1 || ^9"
+        "drupal/core": "~8.9.1 || ^9"
     },
     "conflict": {
         "symfony/phpunit-bridge": "<3.4.5"
@@ -22,6 +22,7 @@
         "composer/installers": "^1.6",
         "drupal/core-composer-scaffold": "~8.9.1 || ^9",
         "drupal/core-dev": "~8.9.1 || ^9",
+        "drupal/core-recommended": "~8.9.1 || ^9",
         "drupal/devel": "^4.0",
         "oomphinc/composer-installers-extender": "^1.1",
         "pronovix/drupal-qa": "^2.11",


### PR DESCRIPTION
Currently, it is impossible to install the latest release of our module on Drupal 8.9 Details are here: https://www.drupal.org/project/infrastructure/issues/3197662