### PR TITLE
Drop Drupal < 9.2 and PHP < 7.4 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,8 +29,7 @@ jobs:
 
     - name: Create Docker containers
       env:
-        PHP_IMAGE: ${{ matrix.php_image }}
-        DB_IMAGE: ${{ matrix.db_image }}
+        PHP_IMAGE: "wodby/drupal-php:7.4-dev"
       run: |
         docker-compose pull --quiet
         docker-compose up -d --build
@@ -48,16 +47,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php_image: ["wodby/drupal-php:7.2-dev", "wodby/drupal-php:7.3-dev", "wodby/drupal-php:7.4-dev"]
+        # TODO Add PHP 8.0 to the test suit when our dev dependencies get a PHP 8.0 compatible release.
+        php_image: ["wodby/drupal-php:7.4-dev"]
         db_image: ["wodby/mariadb:10.5"]
-        drupal_version: ["~8.9.1", "^9"]
+        # TODO Get version range from composer.json dynamically.
+        drupal_version: ["^9.2"]
         lowest_highest: ["--prefer-lowest", ""]
-        exclude:
-          - php_image: "wodby/drupal-php:7.2-dev"
-            drupal_version: "^9"
-          - php_image: "wodby/drupal-php:7.4-dev"
-            drupal_version: "~8.9.1"
-            lowest_highest: "--prefer-lowest"
 
     steps:
     - name: Checkout Swagger UI Formatter

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -9,7 +9,7 @@ $ git clone https://github.com/Pronovix/docker-drupal-dev.git drupal-dev
 $ mkdir build;
 $ ln -s drupal-dev/docker-compose.yml
 $ ln -s drupal-dev/Dockerfile
-$ printf "COMPOSE_PROJECT_NAME=swagger_ui_formatter\n#You can find examples for available customization in the drupal-dev/examples/.env file.\n" > .env && source .env
+$ printf "COMPOSE_PROJECT_NAME=swagger_ui_formatter\nPHP_IMAGE=wodby/drupal-php:7.4-dev\n#You can find examples for available customization in the drupal-dev/examples/.env file.\n" > .env && source .env
 $ docker-compose up -d --build
 $ docker-compose exec php composer install
 $ ln -s ../../../../drupal-dev/drupal/settings.php build/web/sites/default/settings.php

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,8 @@
 {
     "name": "drupal/swagger_ui_formatter",
-    "type": "drupal-module",
     "description": "Provides a Swagger UI field formatter for File and Link fields.",
+    "license": "GPL-2.0-or-later",
+    "type": "drupal-module",
     "keywords": [
         "Drupal",
         "OpenAPI",
@@ -9,27 +10,54 @@
         "API docs"
     ],
     "homepage": "https://www.drupal.org/project/swagger_ui_formatter",
-    "license": "GPL-2.0-or-later",
-    "require": {
-        "php": "^7.2",
-        "drupal/core": "~8.9.1 || ^9"
+    "support": {
+        "issues": "https://github.com/Pronovix/swagger_ui_formatter/issues",
+        "source": "https://github.com/Pronovix/swagger_ui_formatter",
+        "docs": "https://www.drupal.org/docs/8/modules/swagger-ui-field-formatter"
     },
-    "conflict": {
-        "symfony/phpunit-bridge": "<3.4.5"
+    "require": {
+        "php": "^7.4",
+        "drupal/core": "^9.2"
     },
     "require-dev": {
         "bower-asset/swagger-ui": "^3.32.2",
         "composer/installers": "^v2.0.0",
-        "drupal/core-composer-scaffold": "~8.9.1 || ^9",
-        "drupal/core-dev": "~8.9.1 || ^9",
-        "drupal/core-recommended": "~8.9.1 || ^9",
+        "drupal/core-composer-scaffold": "^9.2",
+        "drupal/core-dev": "^9.2",
+        "drupal/core-recommended": "^9.2",
         "drupal/devel": "^4.0",
-        "pronovix/drupal-qa": "^2.14",
-        "pronovix/simple-symlink": "^2.14",
+        "pronovix/drupal-qa": "^3.3",
+        "pronovix/simple-symlink": "^3.1.3",
         "zaporylie/composer-drupal-optimizations": "^1.2"
+    },
+    "repositories": [
+        {
+            "type": "composer",
+            "url": "https://packages.drupal.org/8"
+        },
+        {
+            "type": "composer",
+            "url": "https://asset-packagist.org"
+        }
+    ],
+    "minimum-stability": "dev",
+    "prefer-stable": true,
+    "autoload": {
+        "psr-4": {
+            "Drupal\\swagger_ui_formatter\\": "./src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Drupal\\Tests\\swagger_ui_formatter\\": "./tests/src",
+            "Drupal\\swagger_ui_formatter_test\\": "./tests/modules/swagger_ui_formatter_test/src"
+        }
     },
     "config": {
         "optimize-autoloader": true,
+        "platform": {
+            "php": "7.4.0"
+        },
         "sort-packages": true,
         "vendor-dir": "build/vendor"
     },
@@ -91,29 +119,6 @@
             "phpcs.xml.dist": "build/phpcs.xml.dist"
         }
     },
-    "autoload": {
-        "psr-4": {
-            "Drupal\\swagger_ui_formatter\\": "./src/"
-        }
-    },
-    "autoload-dev": {
-        "psr-4": {
-            "Drupal\\Tests\\swagger_ui_formatter\\": "./tests/src",
-            "Drupal\\swagger_ui_formatter_test\\": "./tests/modules/swagger_ui_formatter_test/src"
-        }
-    },
-    "repositories": [
-        {
-            "type": "composer",
-            "url": "https://packages.drupal.org/8"
-        },
-        {
-            "type": "composer",
-            "url": "https://asset-packagist.org"
-        }
-    ],
-    "minimum-stability": "dev",
-    "prefer-stable": true,
     "scripts": {
         "post-install-cmd": [
             "Pronovix\\SimpleSymlink\\ScriptHandler::createSymlinks"
@@ -121,13 +126,5 @@
         "post-update-cmd": [
             "Pronovix\\SimpleSymlink\\ScriptHandler::createSymlinks"
         ]
-    },
-    "support": {
-        "issues": "https://github.com/Pronovix/swagger_ui_formatter/issues",
-        "source": "https://github.com/Pronovix/swagger_ui_formatter",
-        "docs": "https://www.drupal.org/docs/8/modules/swagger-ui-field-formatter"
-    },
-    "_comment": [
-        "symfony/phpunit-bridge >= 3.4.5 is required because that introduced PHPUnit 7 support: https://github.com/symfony/phpunit-bridge/commit/41759c1ac495aec551ac2036bfe804dc74f61802"
-    ]
+    }
 }

--- a/swagger_ui_formatter.info.yml
+++ b/swagger_ui_formatter.info.yml
@@ -5,5 +5,5 @@ dependencies:
   - drupal:file
 
 type: module
-core_version_requirement: ~8.9.1 || ^9
-php: "7.2"
+core_version_requirement: ^9.2
+php: "7.4"

--- a/tests/modules/swagger_ui_formatter_test/swagger_ui_formatter_test.info.yml
+++ b/tests/modules/swagger_ui_formatter_test/swagger_ui_formatter_test.info.yml
@@ -1,9 +1,9 @@
 name: 'Swagger UI Field Formatter Testing'
 type: module
 description: 'Testing helper module for Swagger UI field formatter.'
-core_version_requirement: ~8.9.1 || ~9.0.0
+core_version_requirement: ^9.2
 package: 'Testing'
-php: "7.2"
+php: "7.4"
 dependencies:
   - drupal:link
   - drupal:node


### PR DESCRIPTION
We are only supporting actively maintained versions.