### PR TITLE
Add Drupal 10 support and update dependencies

### DIFF
--- a/.dev/.ci/check-cs.sh
+++ b/.dev/.ci/check-cs.sh
@@ -3,7 +3,11 @@
 set -e
 
 if [[ ${CHECK_CS} == true ]]; then
-    docker-compose exec -T php composer normalize -d .. --indent-size=4 --indent-style=space --no-update-lock --dry-run
-    docker-compose exec -T php ./vendor/bin/phpcs -s ../phpcs.xml.dist --ignore="contrib/*" web/modules
-    docker-compose exec -T php ./vendor/bin/phpstan analyze -c ../phpstan.neon.dist --no-progress
+    docker-compose exec -T php composer normalize -d .. --no-update-lock --dry-run
+    # Code style must comply with our minimum required PHP version.
+    docker-compose exec -T php ./vendor/bin/phpcs --config-set php_version 80000
+    # @TODO There is a weird file access issue on GHA.
+    # Drupal QA: Unable to set 511 visibility for file at /mnt/files/local_mount.
+    docker-compose exec -T php ./vendor/bin/phpcs -s ./vendor/pronovix/drupal-qa/config/phpcs.xml.dist --ignore="contrib/*,*/build/*" web/modules
+    docker-compose exec -T php ./vendor/bin/phpstan --no-progress
 fi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,7 +53,7 @@ jobs:
         php_image: ["wodby/drupal-php:8.1-dev"]
         db_image: ["wodby/mariadb:10.5"]
         # TODO Get version range from composer.json dynamically.
-        drupal_version: ["^9.3"]
+        drupal_version: ["~9.4.0", "~9.5.0", "^10.0"]
         lowest_highest: ["--prefer-lowest", ""]
 
     steps:
@@ -87,7 +87,7 @@ jobs:
         chmod a+rw .
         docker-compose exec -T php composer install --no-interaction --no-suggest --no-progress -d ..
         chmod a+rw composer.json
-        docker-compose exec -T php composer require drupal/core:${{ matrix.drupal_version }} drupal/core-dev:${{ matrix.drupal_version }} drupal/core-recommended:${{ matrix.drupal_version }} --no-update -d ..
+        docker-compose exec -T php composer require drupal/core:${{ matrix.drupal_version }} drupal/core-dev:${{ matrix.drupal_version }} drupal/core-recommended:${{ matrix.drupal_version }} drupal/core-composer-scaffold:${{ matrix.drupal_version }} --no-update -d ..
         docker-compose exec --env COMPOSER_DISCARD_CHANGES=true -T php composer update --no-progress ${{ matrix.lowest_highest }} -d ..
 
     - name: List installed dependencies

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,8 @@ jobs:
 
     - name: Create Docker containers
       env:
-        PHP_IMAGE: "wodby/drupal-php:7.4-dev"
+        # We run these checks on the lowest supported PHP version.
+        PHP_IMAGE: "wodby/drupal-php:8.0-dev"
       run: |
         docker-compose pull --quiet
         docker-compose up -d --build
@@ -48,7 +49,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php_image: ["wodby/drupal-php:7.4-dev", "wodby/drupal-php:8.0-dev", "wodby/drupal-php:8.1-dev"]
+        php_image: ["wodby/drupal-php:8.0-dev", "wodby/drupal-php:8.1-dev"]
         db_image: ["wodby/mariadb:10.5"]
         # TODO Get version range from composer.json dynamically.
         drupal_version: ["^9.3"]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,8 +30,9 @@ jobs:
 
     - name: Create Docker containers
       env:
-        # We run these checks on the lowest supported PHP version.
-        PHP_IMAGE: "wodby/drupal-php:8.0-dev"
+        # Because DrupalQA requires PHP 8.1 at least, we cannot use our lowest PHP dependency here,
+        # but we have told both PHPCS and PHPStan to run checks for PHP 8.0.
+        PHP_IMAGE: "wodby/drupal-php:8.1-dev"
       run: |
         docker-compose pull --quiet
         docker-compose up -d --build
@@ -49,7 +50,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php_image: ["wodby/drupal-php:8.0-dev", "wodby/drupal-php:8.1-dev"]
+        php_image: ["wodby/drupal-php:8.1-dev"]
         db_image: ["wodby/mariadb:10.5"]
         # TODO Get version range from composer.json dynamically.
         drupal_version: ["^9.3"]
@@ -88,6 +89,9 @@ jobs:
         chmod a+rw composer.json
         docker-compose exec -T php composer require drupal/core:${{ matrix.drupal_version }} drupal/core-dev:${{ matrix.drupal_version }} drupal/core-recommended:${{ matrix.drupal_version }} --no-update -d ..
         docker-compose exec --env COMPOSER_DISCARD_CHANGES=true -T php composer update --no-progress ${{ matrix.lowest_highest }} -d ..
+
+    - name: List installed dependencies
+      run: docker-compose exec -T php composer show -d ..
 
     - name: Set up Drupal settings files
       run: |

--- a/composer.json
+++ b/composer.json
@@ -26,8 +26,7 @@
         "drupal/core-dev": "^9.3",
         "drupal/core-recommended": "^9.3",
         "drupal/devel": "^4.0",
-        "phpstan/extension-installer": "^1.1",
-        "pronovix/drupal-qa": "^3.3",
+        "pronovix/drupal-qa": "^3.11.1",
         "pronovix/simple-symlink": "^3.1.3",
         "zaporylie/composer-drupal-optimizations": "^1.2"
     },
@@ -63,7 +62,7 @@
             "dealerdirect/phpcodesniffer-composer-installer": true,
             "ergebnis/composer-normalize": true,
             "pronovix/drupal-qa": true,
-            "phpstan/extension-installer": true
+            "phpstan/extension-installer": false
         },
         "optimize-autoloader": true,
         "sort-packages": true,
@@ -122,9 +121,16 @@
         "patchLevel": {
             "drupal/core": "-p2"
         },
+        "patches": {
+            "mglaman/phpstan-drupal": {
+                "Exclude build directory from extension discovery [#85]:": "https://github.com/mglaman/phpstan-drupal/pull/85.diff"
+            }
+        },
         "simple-symlinks": {
             ".": "build/web/modules/drupal_module",
-            "phpcs.xml.dist": "build/phpcs.xml.dist"
+            "phpcs.xml.dist": "build/phpcs.xml.dist",
+            "phpstan-baseline.neon": "build/phpstan-baseline.neon",
+            "phpstan.neon.dist": "build/phpstan.neon.dist"
         }
     },
     "scripts": {

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "docs": "https://www.drupal.org/docs/8/modules/swagger-ui-field-formatter"
     },
     "require": {
-        "php": "^7.4 || ~8.0 || ~8.1.6",
+        "php": "~8.0.0 || ~8.1.0",
         "drupal/core": "^9.3"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -15,17 +15,21 @@
         "source": "https://github.com/Pronovix/swagger_ui_formatter",
         "docs": "https://www.drupal.org/docs/8/modules/swagger-ui-field-formatter"
     },
+    "_comment": [
+        "league/container version contraint is here to prevent randomy failed highest-lowest tests caused by this missing fix: https://github.com/thephpleague/container/commit/97a0c39bf37d709d3bbc31d0505cea9373d927e7"
+    ],
     "require": {
         "php": "~8.0.0 || ~8.1.0",
-        "drupal/core": "^9.3"
+        "drupal/core": "^9.4 || ^10.0"
     },
     "require-dev": {
         "bower-asset/swagger-ui": "^3.32.2",
         "composer/installers": "^v2.0.0",
         "drupal/core-composer-scaffold": "^9.3",
-        "drupal/core-dev": "^9.3",
-        "drupal/core-recommended": "^9.3",
-        "drupal/devel": "^4.0",
+        "drupal/core-dev": "^9.4 || ^10.0",
+        "drupal/core-recommended": "^9.4 || ^10.0",
+        "drupal/devel": "^5.0",
+        "league/container": "<4.0.0 || >=4.1.1",
         "pronovix/drupal-qa": "^3.11.1",
         "pronovix/simple-symlink": "^3.1.3",
         "zaporylie/composer-drupal-optimizations": "^1.2"

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3,14 +3,14 @@ parameters:
 		-
 			message: "#^Unsafe usage of new static\\(\\)\\.$#"
 			count: 1
-			path: src/Plugin/Field/FieldFormatter/SwaggerUIFileFormatter.php
+			path: ../src/Plugin/Field/FieldFormatter/SwaggerUIFileFormatter.php
 
 		-
 			message: "#^\\\\Drupal calls should be avoided in classes, use dependency injection instead$#"
 			count: 1
-			path: src/Plugin/Field/FieldFormatter/SwaggerUIFileFormatter.php
+			path: ../src/Plugin/Field/FieldFormatter/SwaggerUIFileFormatter.php
 
 		-
 			message: "#^Unsafe usage of new static\\(\\)\\.$#"
 			count: 1
-			path: src/Plugin/Field/FieldFormatter/SwaggerUILinkFormatter.php
+			path: ../src/Plugin/Field/FieldFormatter/SwaggerUILinkFormatter.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,20 +1,16 @@
 includes:
+  - %rootDir%/../../pronovix/drupal-qa/config/phpstan.drupal-qa.neon
   - phpstan-baseline.neon
 
 parameters:
-  level: 5
-  treatPhpDocTypesAsCertain: false
-  tipsOfTheDay: false
-  reportUnmatchedIgnoredErrors: false
-  # This hardcoded list is not ideal but it looks like PHPStan full-static analyzer has issues with
+  # Our code must compatible with our minimum required PHP version.
+  phpVersion: 80000
+  # TODO This hardcoded list is not ideal but it looks like PHPStan full-static analyzer has issues with
   # symlinks. See: https://github.com/Pronovix/swagger_ui_formatter/pull/84#discussion_r931072893
   paths:
-    - src
-    - tests
-    - swagger_ui_formatter.api.php
-    - swagger_ui_formatter.install
-    - swagger_ui_formatter.module
-    - swagger_ui_formatter.post_update.php
-  excludePaths:
-    - */node_modules/*
-    - */tests/fixtures/*.php
+    - ../src
+    - ../tests
+    - ../swagger_ui_formatter.api.php
+    - ../swagger_ui_formatter.install
+    - ../swagger_ui_formatter.module
+    - ../swagger_ui_formatter.post_update.php

--- a/src/Plugin/Field/FieldFormatter/SwaggerUILinkFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/SwaggerUILinkFormatter.php
@@ -49,7 +49,7 @@ class SwaggerUILinkFormatter extends FormatterBase implements ContainerFactoryPl
    * @param \Drupal\Core\StringTranslation\TranslationInterface $string_translation
    *   String translation.
    */
-  public function __construct(string $plugin_id, $plugin_definition, FieldDefinitionInterface $field_definition, array $settings, string $label, string $view_mode, array $third_party_settings, TranslationInterface $string_translation) {
+  public function __construct(string $plugin_id, mixed $plugin_definition, FieldDefinitionInterface $field_definition, array $settings, string $label, string $view_mode, array $third_party_settings, TranslationInterface $string_translation) {
     parent::__construct($plugin_id, $plugin_definition, $field_definition, $settings, $label, $view_mode, $third_party_settings);
     $this->stringTranslation = $string_translation;
   }

--- a/swagger_ui_formatter.info.yml
+++ b/swagger_ui_formatter.info.yml
@@ -5,4 +5,4 @@ dependencies:
   - drupal:file
 
 type: module
-core_version_requirement: ^9.3
+core_version_requirement: ^9.4 || ^10.0

--- a/tests/modules/swagger_ui_formatter_test/swagger_ui_formatter_test.info.yml
+++ b/tests/modules/swagger_ui_formatter_test/swagger_ui_formatter_test.info.yml
@@ -1,9 +1,8 @@
 name: 'Swagger UI Field Formatter Testing'
 type: module
 description: 'Testing helper module for Swagger UI field formatter.'
-core_version_requirement: ^9.2
+core_version_requirement: ^9.4 || ^10.0
 package: 'Testing'
-php: "7.4"
 dependencies:
   - drupal:link
   - drupal:node


### PR DESCRIPTION
Closes #89 #88 

After several turnarounds and "it must be Friday" facepalms my final conclusion that PHP 8.0 compatibility cannot be tested because DrupalQA does not support it... without DrupalQA it is close to impossible to run the test suite with highest lowest testing because random errors appears in every builds. (Without DrupalQA PHPUnit 8.x gets installed in some builds...)

But since all static code analyzers runs with PHP 8.0 version compatibility mode, I am confident that this code is PHP 8.0 compatible and after one tagged release, I am planning to drop PHP 8.0 completely. That is the gift we can give the community, otherwise everybody SHOULD use PHP 8.1.