### PR TITLE
Fix BigPipe compatibility issue

### DIFF
--- a/js/swagger-ui-formatter.js
+++ b/js/swagger-ui-formatter.js
@@ -3,59 +3,61 @@
  * Custom scripts to render file fields with Swagger UI.
  */
 
-(function ($, window, Drupal, drupalSettings) {
+(function ($, window, Drupal, drupalSettings, once) {
 
   Drupal.behaviors.swaggerUIFormatter = {
     attach: function (context) {
-      // Iterate over field values and render each field value with Swagger UI.
-      for (var fieldNamePlusDelta in drupalSettings.swaggerUIFormatter) {
-        if (drupalSettings.swaggerUIFormatter.hasOwnProperty(fieldNamePlusDelta)) {
-          var fieldElementInField = drupalSettings.swaggerUIFormatter[fieldNamePlusDelta];
-          // Do not instantiate/re-render Swagger UI if it has been done
-          // before (avoid re-rendering on AJAX requests for example).
-          if ('swagger_ui_' + fieldNamePlusDelta in window) {
-            continue;
+      once('swaggerUIFormatter', '[id^="swagger-ui-"]', context).forEach(() => {
+        // Iterate over field values and render each field value with Swagger UI.
+        for (var fieldNamePlusDelta in drupalSettings.swaggerUIFormatter) {
+          if (drupalSettings.swaggerUIFormatter.hasOwnProperty(fieldNamePlusDelta)) {
+            var fieldElementInField = drupalSettings.swaggerUIFormatter[fieldNamePlusDelta];
+            // Do not instantiate/re-render Swagger UI if it has been done
+            // before (avoid re-rendering on AJAX requests for example).
+            if ('swagger_ui_' + fieldNamePlusDelta in window) {
+              continue;
+            }
+
+            var validatorUrl = undefined;
+            switch (fieldElementInField.validator) {
+              case 'custom':
+                validatorUrl = fieldElementInField.validatorUrl;
+                break;
+
+              case 'none':
+                validatorUrl = null;
+                break;
+            }
+
+            var options = {
+              url: fieldElementInField.swaggerFile,
+              dom_id: '#swagger-ui-' + fieldNamePlusDelta,
+              deepLinking: true,
+              presets: [
+                SwaggerUIBundle.presets.apis,
+                // This is a dirty hack but it works out of the box.
+                // See https://github.com/swagger-api/swagger-ui/issues/3229.
+                fieldElementInField.showTopBar ? SwaggerUIStandalonePreset : SwaggerUIStandalonePreset.slice(1)
+              ],
+              plugins: [
+                SwaggerUIBundle.plugins.DownloadUrl
+              ],
+              validatorUrl: validatorUrl,
+              docExpansion: fieldElementInField.docExpansion,
+              layout: "StandaloneLayout",
+              tagsSorter: fieldElementInField.sortTagsByName ? 'alpha' : '',
+              supportedSubmitMethods: fieldElementInField.supportedSubmitMethods,
+              oauth2RedirectUrl: fieldElementInField.oauth2RedirectUrl
+            };
+
+            // Allow altering the options.
+            $(window).trigger('swaggerUIFormatterOptionsAlter', options);
+
+            window['swagger_ui_' + fieldNamePlusDelta] = SwaggerUIBundle(options);
           }
-
-          var validatorUrl = undefined;
-          switch (fieldElementInField.validator) {
-            case 'custom':
-              validatorUrl = fieldElementInField.validatorUrl;
-              break;
-
-            case 'none':
-              validatorUrl = null;
-              break;
-          }
-
-          var options = {
-            url: fieldElementInField.swaggerFile,
-            dom_id: '#swagger-ui-' + fieldNamePlusDelta,
-            deepLinking: true,
-            presets: [
-              SwaggerUIBundle.presets.apis,
-              // This is a dirty hack but it works out of the box.
-              // See https://github.com/swagger-api/swagger-ui/issues/3229.
-              fieldElementInField.showTopBar ? SwaggerUIStandalonePreset : SwaggerUIStandalonePreset.slice(1)
-            ],
-            plugins: [
-              SwaggerUIBundle.plugins.DownloadUrl
-            ],
-            validatorUrl: validatorUrl,
-            docExpansion: fieldElementInField.docExpansion,
-            layout: "StandaloneLayout",
-            tagsSorter: fieldElementInField.sortTagsByName ? 'alpha' : '',
-            supportedSubmitMethods: fieldElementInField.supportedSubmitMethods,
-            oauth2RedirectUrl: fieldElementInField.oauth2RedirectUrl
-          };
-
-          // Allow altering the options.
-          $(window).trigger('swaggerUIFormatterOptionsAlter', options);
-
-          window['swagger_ui_' + fieldNamePlusDelta] = SwaggerUIBundle(options);
         }
-      }
+      });
     }
   };
 
-}(jQuery, window, Drupal, drupalSettings));
+}(jQuery, window, Drupal, drupalSettings, once));

--- a/swagger_ui_formatter.module
+++ b/swagger_ui_formatter.module
@@ -69,6 +69,7 @@ function swagger_ui_formatter_library_info_build(): array {
       'core/drupal',
       'core/jquery',
       'core/drupalSettings',
+      'core/once',
       'swagger_ui_formatter/swagger_ui_formatter.swagger_ui',
     ],
   ];

--- a/swagger_ui_formatter.module
+++ b/swagger_ui_formatter.module
@@ -61,7 +61,6 @@ function swagger_ui_formatter_library_info_build(): array {
   ];
   // Library definition for the Swagger UI integration files.
   $libraries['swagger_ui_formatter.swagger_ui_integration'] = [
-    'version' => '1.0',
     'js' => [
       'js/swagger-ui-formatter.js' => [],
     ],


### PR DESCRIPTION
The current implementation of swagger-ui-formatter.js doesn't properly check if the element it receives through Drupal behaviors contains Swagger UI elements before attempting to initialize. When BigPipe is enabled, the script runs against every progressive element, including the admin toolbar which gets loaded first.

This causes the script to prematurely fire the loaded event before the actual Swagger UI content is rendered which could break event subscribers that properly checks whether Swagger UI is loaded or not.