### PR TITLE
Bundled installation: Fix Swagger UI start issue on React 19

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,12 +9,13 @@
     "develop": "webpack --mode development --devtool source-map --watch --progress"
   },
   "dependencies": {
-    "swagger-ui": "^5.17.14"
+    "swagger-ui-dist": "^5.17.14"
   },
   "devDependencies": {
     "copy-webpack-plugin": "^12.0.2",
     "css-loader": "^6.8.0",
     "mini-css-extract-plugin": "^2.9.4",
+    "path-browserify": "^1.0.1",
     "webpack": "^5.88.0",
     "webpack-cli": "^5.1.0"
   }

--- a/frontend/src/SwaggerUIMainLoader.js
+++ b/frontend/src/SwaggerUIMainLoader.js
@@ -3,7 +3,7 @@
  * @internal
  */
 
-import 'swagger-ui/dist/swagger-ui.css';
-import SwaggerUI from 'swagger-ui';
+import 'swagger-ui-dist/swagger-ui.css';
+import { SwaggerUIBundle } from 'swagger-ui-dist';
 
-window.SwaggerUIBundle = SwaggerUI;
+window.SwaggerUIBundle = SwaggerUIBundle;

--- a/frontend/src/SwaggerUIStandalonePresetLoader.js
+++ b/frontend/src/SwaggerUIStandalonePresetLoader.js
@@ -3,6 +3,6 @@
  * @internal
  */
 
-import SwaggerUIStandalonePreset from 'swagger-ui/dist/swagger-ui-standalone-preset';
+import { SwaggerUIStandalonePreset } from 'swagger-ui-dist';
 
 window.SwaggerUIStandalonePreset = SwaggerUIStandalonePreset;

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -28,7 +28,7 @@ module.exports = (env, argv) => {
       new CopyWebpackPlugin({
         patterns: [
           {
-            from: require.resolve('swagger-ui/dist/oauth2-redirect.html'),
+            from: require.resolve('swagger-ui-dist/oauth2-redirect.html'),
             to: path.resolve(__dirname, 'dist/oauth2-redirect.html')
           }
         ]
@@ -47,6 +47,11 @@ module.exports = (env, argv) => {
           terserOptions: { ecma: 2020 }
         })
       ],
+    },
+    resolve: {
+      fallback: {
+        "path": require.resolve("path-browserify")
+      }
     },
     devtool: isProduction ? false : 'source-map'
   }

--- a/frontend/write_swagger_ui_version_file.js
+++ b/frontend/write_swagger_ui_version_file.js
@@ -11,7 +11,7 @@ const path = require('path');
  * The name of the npm package to find the version for.
  * @const {string}
  */
-const packageName = 'swagger-ui';
+const packageName = 'swagger-ui-dist';
 
 /**
  * The absolute path to the output file where the version will be stored.
@@ -22,7 +22,7 @@ const outputFilePath = path.join(__dirname, 'swagger_ui_version.json');
 try {
   // Get the directory containing the package from its main file path.
   const packageMain = require.resolve(packageName);
-  const packageJsonPath = path.join(path.dirname(packageMain), '../package.json');
+  const packageJsonPath = path.join(path.dirname(packageMain), './package.json');
 
   // Read the package.json file and parse it.
   const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));


### PR DESCRIPTION
SwaggerUI version 5.28.0 the swagger-ui npm package allows for React 19. This causes runtime issues while using the Standalone preset. Use swagger-ui-dist, which comes already as a bundle, so we don't need to resolve SwaggerUI internal dependencies.

Closes #119 