### PR TITLE
Optimize Webpack build

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,9 +13,6 @@
   },
   "devDependencies": {
     "copy-webpack-plugin": "^12.0.2",
-    "css-loader": "^6.8.0",
-    "mini-css-extract-plugin": "^2.9.4",
-    "path-browserify": "^1.0.1",
     "webpack": "^5.88.0",
     "webpack-cli": "^5.1.0"
   }

--- a/frontend/src/SwaggerUIMainLoader.js
+++ b/frontend/src/SwaggerUIMainLoader.js
@@ -1,9 +1,0 @@
-/**
- * @file Exposes the Swagger UI bundle initialization function on the global window object.
- * @internal
- */
-
-import 'swagger-ui-dist/swagger-ui.css';
-import { SwaggerUIBundle } from 'swagger-ui-dist';
-
-window.SwaggerUIBundle = SwaggerUIBundle;

--- a/frontend/src/SwaggerUIStandalonePresetLoader.js
+++ b/frontend/src/SwaggerUIStandalonePresetLoader.js
@@ -1,8 +1,0 @@
-/**
- * @file Exposes the Swagger UI standalone preset on the global window object.
- * @internal
- */
-
-import { SwaggerUIStandalonePreset } from 'swagger-ui-dist';
-
-window.SwaggerUIStandalonePreset = SwaggerUIStandalonePreset;

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1,0 +1,1 @@
+// This file serves as an entry point for Webpack.

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -1,32 +1,25 @@
 const path = require('path');
-const MiniCssExtractPlugin = require('mini-css-extract-plugin');
-const TerserPlugin = require('terser-webpack-plugin');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
+const TerserPlugin = require('terser-webpack-plugin');
 
 module.exports = (env, argv) => {
-  const isProduction = argv.mode === 'production';
   return {
-    entry: {
-      'swagger-ui-bundle': './src/SwaggerUIMainLoader.js',
-      'swagger-ui-standalone-preset': './src/SwaggerUIStandalonePresetLoader.js'
-    },
-    module: {
-      rules: [
-        {
-          test: /\.css$/i,
-          use: [
-            MiniCssExtractPlugin.loader,
-            'css-loader'
-          ]
-        }
-      ]
-    },
+    entry: './src/index.js',
     plugins: [
-      new MiniCssExtractPlugin({
-        filename: 'swagger-ui.css'
-      }),
       new CopyWebpackPlugin({
         patterns: [
+          {
+            from: require.resolve('swagger-ui-dist/swagger-ui-bundle.js'),
+            to: path.resolve(__dirname, 'dist/swagger-ui-bundle.js')
+          },
+          {
+            from: require.resolve('swagger-ui-dist/swagger-ui-standalone-preset.js'),
+            to: path.resolve(__dirname, 'dist/swagger-ui-standalone-preset.js')
+          },
+          {
+            from: require.resolve('swagger-ui-dist/swagger-ui.css'),
+            to: path.resolve(__dirname, 'dist/swagger-ui.css')
+          },
           {
             from: require.resolve('swagger-ui-dist/oauth2-redirect.html'),
             to: path.resolve(__dirname, 'dist/oauth2-redirect.html')
@@ -39,24 +32,15 @@ module.exports = (env, argv) => {
       })
     ],
     output: {
-      filename: '[name].js',
       path: path.resolve(__dirname, 'dist'),
       clean: true
     },
     optimization: {
-      minimize: isProduction,
       minimizer: [
         new TerserPlugin({
-          parallel: true,
-          terserOptions: { ecma: 2020 }
-        })
+          extractComments: false,
+        }),
       ],
     },
-    resolve: {
-      fallback: {
-        "path": require.resolve("path-browserify")
-      }
-    },
-    devtool: isProduction ? false : 'source-map'
   }
 };


### PR DESCRIPTION
so it only copies the prebuilt SwaggerUI files.
This simplifies setup and reduces bundle sizes.