### PR TITLE
Bump copy-webpack-plugin version

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,7 +15,7 @@
     "swagger-ui-dist": "^5.29.2"
   },
   "devDependencies": {
-    "copy-webpack-plugin": "^12.0.2",
+    "copy-webpack-plugin": "^14.0.0",
     "terser-webpack-plugin": "^5.6.1",
     "webpack": "^5.88.0",
     "webpack-cli": "^5.1.0"


### PR DESCRIPTION
because it depends on vulnerable versions of serialize-javascript package.